### PR TITLE
[fix] Compute embedding cosine distance

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -76,6 +76,10 @@ impl Embedding {
         Ok(embeddings.data.swap_remove(0))
     }
 
+    pub fn magnitude(&self) -> f64 {
+        self.vec.iter().map(|x| x * x).sum::<f64>().sqrt()
+    }
+
     pub fn distance(&self, other: &Self) -> f64 {
         let dot_product: f64 = self
             .vec
@@ -83,9 +87,9 @@ impl Embedding {
             .zip(other.vec.iter())
             .map(|(x, y)| x * y)
             .sum();
-        let product_of_lengths = (self.vec.len() * other.vec.len()) as f64;
+        let product_of_magnitudes = self.magnitude() * other.magnitude();
 
-        dot_product / product_of_lengths
+        1.0 - dot_product / product_of_magnitudes
     }
 }
 
@@ -145,8 +149,7 @@ mod tests {
                 total_tokens: 0,
             },
         };
-
-        assert_eq!(embeddings.distances()[0], 0.0);
+        assert_eq!(embeddings.distances()[0], 1.0);
     }
 
     #[test]
@@ -167,6 +170,6 @@ mod tests {
             },
         };
 
-        assert_ne!(embeddings.distances()[0], 0.0);
+        assert_eq!(embeddings.distances()[0], 0.29289321881345254);
     }
 }


### PR DESCRIPTION
Distance between embeddings is typically cosine distance. That is the complement of the dot product over the product of vector norm/magnitude/length. 1 - (a dot b) / (||a|| * ||b|)

It looks like the terminology on the denominator might have been ambiguous so it was implemented as product of the length of the embedding arrays, which is always the same and produced incorrect results. 

This is a more typical implementation and produces verifiably correct results. The tests have been updated to check these.

Test plan:
- Computed cosine distance using another calculator and compared with result for test
- Used existing tests, new tests are green
- Patched local app to compare results from this crate vs. a javascript implementation of cosine distance. Results are identical within 6 sig digits.