### PR TITLE
fix: change order of ApiResponse discriminants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ impl std::error::Error for OpenAiError {}
 #[derive(Deserialize, Clone)]
 #[serde(untagged)]
 pub enum ApiResponse<T> {
-    Ok(T),
     Err { error: OpenAiError },
+    Ok(T),
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]


### PR DESCRIPTION
Change the order of `Ok` and `Err` because [`untagged`](https://serde.rs/enum-representations.html#untagged) will deserialize each variant in order of appearance and the `Ok` variant is too generic to fall through to `Err`.