### PR TITLE
Add Error implementation for ChatCompletionDeltaMergeError

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -577,7 +577,7 @@ mod tests {
         set_key(env::var("OPENAI_KEY").unwrap());
 
         let chat_stream = ChatCompletion::builder(
-            "gpt-3.5-turbo-0613",
+            "gpt-4o",
             [
                 ChatCompletionMessage {
                     role: ChatCompletionMessageRole::User,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -9,6 +9,8 @@ use reqwest_eventsource::{CannotCloneRequestError, Event, EventSource};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter, Write};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// A full chat completion.
@@ -402,6 +404,18 @@ pub enum ChatCompletionDeltaMergeError {
     DifferentCompletionChoiceIndices,
     FunctionCallArgumentTypeMismatch,
 }
+
+impl Display for ChatCompletionDeltaMergeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChatCompletionDeltaMergeError::DifferentCompletionIds => f.write_str("Different completion IDs"),
+            ChatCompletionDeltaMergeError::DifferentCompletionChoiceIndices => f.write_str("Different completion choice indices"),
+            ChatCompletionDeltaMergeError::FunctionCallArgumentTypeMismatch => f.write_str("Function call argument type mismatch"),
+        }
+    }
+}
+
+impl Error for ChatCompletionDeltaMergeError {}
 
 async fn forward_deserialized_chat_response_stream(
     mut stream: EventSource,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -9,8 +9,6 @@ use reqwest_eventsource::{CannotCloneRequestError, Event, EventSource};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::{Display, Formatter, Write};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// A full chat completion.
@@ -405,17 +403,23 @@ pub enum ChatCompletionDeltaMergeError {
     FunctionCallArgumentTypeMismatch,
 }
 
-impl Display for ChatCompletionDeltaMergeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for ChatCompletionDeltaMergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ChatCompletionDeltaMergeError::DifferentCompletionIds => f.write_str("Different completion IDs"),
-            ChatCompletionDeltaMergeError::DifferentCompletionChoiceIndices => f.write_str("Different completion choice indices"),
-            ChatCompletionDeltaMergeError::FunctionCallArgumentTypeMismatch => f.write_str("Function call argument type mismatch"),
+            ChatCompletionDeltaMergeError::DifferentCompletionIds => {
+                f.write_str("Different completion IDs")
+            }
+            ChatCompletionDeltaMergeError::DifferentCompletionChoiceIndices => {
+                f.write_str("Different completion choice indices")
+            }
+            ChatCompletionDeltaMergeError::FunctionCallArgumentTypeMismatch => {
+                f.write_str("Function call argument type mismatch")
+            }
         }
     }
 }
 
-impl Error for ChatCompletionDeltaMergeError {}
+impl std::error::Error for ChatCompletionDeltaMergeError {}
 
 async fn forward_deserialized_chat_response_stream(
     mut stream: EventSource,

--- a/src/files.rs
+++ b/src/files.rs
@@ -377,7 +377,6 @@ mod tests {
         let request = test_upload_request();
         let file_upload_path = Path::new(request.file_name.as_str());
         let file_name = file_upload_path
-            .clone()
             .file_name()
             .unwrap()
             .to_str()

--- a/src/files.rs
+++ b/src/files.rs
@@ -376,11 +376,7 @@ mod tests {
     fn file_name_path_test() {
         let request = test_upload_request();
         let file_upload_path = Path::new(request.file_name.as_str());
-        let file_name = file_upload_path
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap();
+        let file_name = file_upload_path.file_name().unwrap().to_str().unwrap();
         assert_eq!(file_name, "file_upload_test1.jsonl");
         let file_upload_path = file_upload_path.canonicalize().unwrap();
         let file_exists = file_upload_path.exists();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ impl OpenAiError {
 
 impl std::fmt::Display for OpenAiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
+        f.write_str(&self.message)
     }
 }
 


### PR DESCRIPTION
I noticed that `impl Error for ChatCompletionDeltaMergeError` was missing, so I implemented it. The type can now be trivially used with `anyhow`, `eyre` etc.

---

Some of the tests are failing but that seems to be outside of the scope of my change.