### PR TITLE
feat: add new developer role

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -164,6 +164,7 @@ pub enum ChatCompletionMessageRole {
     Assistant,
     Function,
     Tool,
+    Developer,
 }
 
 #[derive(Serialize, Builder, Debug, Clone)]


### PR DESCRIPTION
Add the new developer role for the chat completions.
This is documented by openai here: https://platform.openai.com/docs/guides/reasoning#advice-on-prompting

Also, throughout their platform, this parameter seems to be used more and more.