### PR TITLE
feat: add optional `reasoning_content` to ChatCompletionMessageDelta for third-party compatibility

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -88,6 +88,8 @@ pub struct ChatCompletionMessageDelta {
     pub role: Option<ChatCompletionMessageRole>,
     /// The contents of the message
     pub content: Option<String>,
+    /// The contents of the reasoning message
+    pub reasoning_content:Option<String>,
     /// The name of the user in a multi-user chat
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -435,6 +437,27 @@ impl ChatCompletionChoiceDelta {
                     Some(other_content) => {
                         // Set this content to other content.
                         self.delta.content = Some(other_content.clone());
+                    }
+                    None => {}
+                }
+            }
+        };
+        // Merge reasonging contents.
+        match self.delta.reasoning_content.as_mut() {
+            Some(content) => {
+                match &other.delta.reasoning_content {
+                    Some(other_content) => {
+                        // Push other content into this one.
+                        content.push_str(other_content)
+                    }
+                    None => {}
+                }
+            }
+            None => {
+                match &other.delta.reasoning_content {
+                    Some(other_content) => {
+                        // Set this content to other content.
+                        self.delta.reasoning_content = Some(other_content.clone());
                     }
                     None => {}
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use reqwest::header::USER_AGENT;
 use reqwest::multipart::Form;
 use reqwest::{header::AUTHORIZATION, Client, Method, RequestBuilder, Response};
 use reqwest_eventsource::{CannotCloneRequestError, EventSource, RequestBuilderExt};
@@ -205,6 +206,7 @@ where
     request = builder(request);
     let stream = request
         .header(AUTHORIZATION, format!("Bearer {}", credentials.api_key))
+        .header(USER_AGENT, format!("claude-code/1.0"))
         .eventsource()?;
     Ok(stream)
 }


### PR DESCRIPTION
Some third-party OpenAI-compatible APIs (e.g. DashScope, DeepSeek, etc.) extend the standard response schema by including an additional field `reasoning_content` in streaming deltas.