### PR TITLE
feat: add optional `reasoning_content` to ChatCompletionMessageDelta for third-party compatibility

### DIFF
--- a/examples/chat_reasoning_simple.rs
+++ b/examples/chat_reasoning_simple.rs
@@ -1,11 +1,11 @@
-use std::io::{Write, stdout};
+use std::io::{stdout, Write};
 
 use dotenvy::dotenv;
 use openai::{
-    Credentials,
     chat::{ChatCompletion, ChatCompletionDelta, ChatCompletionMessage, ChatCompletionMessageRole},
+    Credentials,
 };
-use tokio::sync::mpsc::{Receiver, error::TryRecvError};
+use tokio::sync::mpsc::{error::TryRecvError, Receiver};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -19,7 +19,7 @@ async fn main() {
 
     stdout().flush().unwrap();
 
-    let  user_message_content = "what tools do you have?".to_string();
+    let user_message_content = "what tools do you have?".to_string();
 
     messages.push(ChatCompletionMessage {
         role: ChatCompletionMessageRole::User,

--- a/examples/chat_reasoning_simple.rs
+++ b/examples/chat_reasoning_simple.rs
@@ -1,0 +1,87 @@
+use std::io::{Write, stdout};
+
+use dotenvy::dotenv;
+use openai::{
+    Credentials,
+    chat::{ChatCompletion, ChatCompletionDelta, ChatCompletionMessage, ChatCompletionMessageRole},
+};
+use tokio::sync::mpsc::{Receiver, error::TryRecvError};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    dotenv().unwrap();
+    let credentials = Credentials::from_env();
+    let mut messages = vec![ChatCompletionMessage {
+        role: ChatCompletionMessageRole::System,
+        content: Some("You're an AI that replies to each message verbosely.".to_string()),
+        ..Default::default()
+    }];
+
+    stdout().flush().unwrap();
+
+    let  user_message_content = "what tools do you have?".to_string();
+
+    messages.push(ChatCompletionMessage {
+        role: ChatCompletionMessageRole::User,
+        content: Some(user_message_content),
+        ..Default::default()
+    });
+
+    let chat_stream = ChatCompletionDelta::builder("qwen3.5-plus", messages.clone())
+        .credentials(credentials.clone())
+        .create_stream()
+        .await
+        .unwrap();
+
+    let chat_completion: ChatCompletion = listen_for_tokens(chat_stream).await;
+    let returned_message = chat_completion.choices.first().unwrap().message.clone();
+
+    messages.push(returned_message);
+}
+
+async fn listen_for_tokens(mut chat_stream: Receiver<ChatCompletionDelta>) -> ChatCompletion {
+    let mut merged: Option<ChatCompletionDelta> = None;
+    let mut thingking = false;
+    loop {
+        match chat_stream.try_recv() {
+            Ok(delta) => {
+                let choice = &delta.choices[0];
+
+                if let Some(role) = &choice.delta.role {
+                    print!("{:#?}: ", role);
+                }
+                if thingking == false && choice.delta.reasoning_content.is_some() {
+                    thingking = true;
+                    print!("🤔 -> \n");
+                }
+                if thingking == true && choice.delta.reasoning_content.is_none() {
+                    thingking = false;
+                    print!("\n😄 -> \n");
+                }
+                if let Some(content) = &choice.delta.content {
+                    print!("{}", content);
+                }
+                if let Some(reason_content) = &choice.delta.reasoning_content {
+                    print!("{}", reason_content);
+                }
+                stdout().flush().unwrap();
+                // Merge token into full completion.
+                match merged.as_mut() {
+                    Some(c) => {
+                        c.merge(delta).unwrap();
+                    }
+                    None => merged = Some(delta),
+                };
+            }
+            Err(TryRecvError::Empty) => {
+                let duration = std::time::Duration::from_millis(50);
+                tokio::time::sleep(duration).await;
+            }
+            Err(TryRecvError::Disconnected) => {
+                break;
+            }
+        };
+    }
+    println!();
+    merged.unwrap().into()
+}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -89,7 +89,8 @@ pub struct ChatCompletionMessageDelta {
     /// The contents of the message
     pub content: Option<String>,
     /// The contents of the reasoning message
-    pub reasoning_content:Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     /// The name of the user in a multi-user chat
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -88,6 +88,8 @@ pub struct ChatCompletionMessageDelta {
     pub role: Option<ChatCompletionMessageRole>,
     /// The contents of the message
     pub content: Option<String>,
+    /// The contents of the reasoning message
+    pub reasoning_content:Option<String>,
     /// The name of the user in a multi-user chat
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -435,6 +437,27 @@ impl ChatCompletionChoiceDelta {
                     Some(other_content) => {
                         // Set this content to other content.
                         self.delta.content = Some(other_content.clone());
+                    }
+                    None => {}
+                }
+            }
+        };
+        // Merge reasonging contents.
+        match self.delta.reasoning_content.as_mut() {
+            Some(content) => {
+                match &other.delta.reasoning_content {
+                    Some(other_content) => {
+                        // Push other content into this one.
+                        content.push_str(other_content)
+                    }
+                    None => {}
+                }
+            }
+            None => {
+                match &other.delta.reasoning_content {
+                    Some(other_content) => {
+                        // Set this content to other content.
+                        self.delta.reasoning_content = Some(other_content.clone());
                     }
                     None => {}
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ where
     request = builder(request);
     let response = request
         .header(AUTHORIZATION, format!("Bearer {}", credentials.api_key))
+        .header(USER_AGENT, format!("openai"))
         .send()
         .await?;
     Ok(response)
@@ -206,7 +207,7 @@ where
     request = builder(request);
     let stream = request
         .header(AUTHORIZATION, format!("Bearer {}", credentials.api_key))
-        .header(USER_AGENT, format!("claude-code/1.0"))
+        .header(USER_AGENT, format!("openai"))
         .eventsource()?;
     Ok(stream)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use reqwest::header::USER_AGENT;
 use reqwest::multipart::Form;
 use reqwest::{header::AUTHORIZATION, Client, Method, RequestBuilder, Response};
 use reqwest_eventsource::{CannotCloneRequestError, EventSource, RequestBuilderExt};
@@ -205,6 +206,7 @@ where
     request = builder(request);
     let stream = request
         .header(AUTHORIZATION, format!("Bearer {}", credentials.api_key))
+        .header(USER_AGENT, format!("claude-code/1.0"))
         .eventsource()?;
     Ok(stream)
 }


### PR DESCRIPTION
Some third-party OpenAI-compatible APIs (e.g. DashScope, DeepSeek, etc.) extend the standard response schema by including an additional field `reasoning_content` in streaming deltas.