### PR TITLE
Add support for `reasoning_effort` and `extra_body parameters` to `ChatCompletionRequest`

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -179,6 +179,13 @@ pub enum ChatCompletionMessageRole {
 #[builder(name = "ChatCompletionBuilder")]
 #[builder(setter(strip_option, into))]
 pub struct ChatCompletionRequest {
+    /// Additional JSON properties to merge into the request body.
+    ///
+    /// If a key overlaps with a typed field, the typed field value wins.
+    #[builder(default)]
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<HashMap<String, Value>>,
     /// ID of the model to use. Currently, only `gpt-3.5-turbo`, `gpt-3.5-turbo-0301` and `gpt-4`
     /// are supported.
     model: String,
@@ -220,6 +227,10 @@ pub struct ChatCompletionRequest {
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     max_completion_tokens: Option<u64>,
+    /// Constrains effort on reasoning for reasoning-capable models.
+    #[builder(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<String>,
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
     ///
     /// [See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)


### PR DESCRIPTION
- `reasoning_effort`: Constrains inference effort for reasoning-capable models 
- `extra_body`: Enables passing arbitrary JSON properties not yet typed in the SDK, providing forward compatibility with new API parameters without requiring SDK updates.

Usage:

```rust
// Reasoning effort
let req = ChatCompletion::builder("o3-mini", messages)
    .reasoning_effort("high")
    .build()?;

// Extra body
let mut extra = HashMap::new();
extra.insert("custom_param".into(), json!("custom"));
let req = ChatCompletion::builder("gpt-4o", messages)
    .extra_body(extra)
    .build()?;
```
